### PR TITLE
Fix import paths

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     cgo: false
 repository:
-    path: github.com/BonnierNews/logstash_exporter
+    path: github.com/Subito-it/logstash_exporter
 build:
     binaries:
         - name: logstash_exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM golang:1.9 as golang
 
-ADD . $GOPATH/src/github.com/BonnierNews/logstash_exporter/
+ADD . $GOPATH/src/github.com/Subito-it/logstash_exporter/
 RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 && \
         chmod +x /usr/local/bin/dep && \
-        go get -u github.com/BonnierNews/logstash_exporter && \
-        cd $GOPATH/src/github.com/BonnierNews/logstash_exporter && \
+        go get -u github.com/Subito-it/logstash_exporter && \
+        cd $GOPATH/src/github.com/Subito-it/logstash_exporter && \
         dep ensure && \
         make
 
 FROM busybox:1.27.2-glibc
-COPY --from=golang /go/src/github.com/BonnierNews/logstash_exporter/logstash_exporter /
+COPY --from=golang /go/src/github.com/Subito-it/logstash_exporter/logstash_exporter /
 LABEL maintainer christoffer.kylvag@bonniernews.se
 EXPOSE 9198
-ENTRYPOINT ["/logstash_exporter"]  
+ENTRYPOINT ["/logstash_exporter"]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Prometheus exporter for the metrics available in Logstash since version 5.0.
 ## Usage
 
 ```bash
-go get -u github.com/BonnierNews/logstash_exporter
-cd $GOPATH/src/github.com/BonnierNews/logstash_exporter
+go get -u github.com/Subito-it/logstash_exporter
+cd $GOPATH/src/github.com/Subito-it/logstash_exporter
 make
 ./logstash_exporter -exporter.bind_address :1234 -logstash.endpoint http://localhost:1235
 ```

--- a/logstash_exporter.go
+++ b/logstash_exporter.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/BonnierNews/logstash_exporter/collector"
+	"github.com/Subito-it/logstash_exporter/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"


### PR DESCRIPTION
Replace references to the upstream repository `BonnierNews/logstash_exporter` by the forked version `Subito-it/logstash_exporter`
